### PR TITLE
[Docker] Upgrade Node.js to v22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/node:20-alpine
+FROM docker.io/library/node:22-alpine
 
 # build the app
 WORKDIR /app


### PR DESCRIPTION
The base image was using version 20, let's upgrade it to the current LTS which is 22.